### PR TITLE
chore: migrate backend with base v4.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>at.tugraz</groupId>
   <artifactId>damap</artifactId>
-  <version>4.2.0</version>
+  <version>4.3.0</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>A tool for machine actionable DMPs.</description>
@@ -31,8 +31,8 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>3.11.1</quarkus.platform.version>
-    <spotless.version>2.44.0.BETA1</spotless.version>
-  </properties>
+    <spotless.version>2.44.0.BETA1</spotless.version>  
+    </properties>
 
   <dependencyManagement>
     <dependencies>
@@ -51,10 +51,10 @@
     <dependency>
       <groupId>org.damap</groupId>
       <artifactId>base</artifactId>
-      <version>4.3.1</version>
+      <version>4.5.0</version>
     </dependency>
     <!-- Test -->
-    <dependency>
+   <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jacoco</artifactId>
       <scope>test</scope>
@@ -167,7 +167,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.32</version>
+      <version>1.18.24</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Migration with base v4.5.0 for us v4.3.0 