### PR TITLE
feat: upgrade to DAMAP 4.5.2 and add contributor role support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,10 +51,10 @@
     <dependency>
       <groupId>org.damap</groupId>
       <artifactId>base</artifactId>
-      <version>4.5.0</version>
+      <version>4.5.2</version>
     </dependency>
     <!-- Test -->
-   <dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jacoco</artifactId>
       <scope>test</scope>
@@ -167,7 +167,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.24</version>
+      <version>1.18.30</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/main/resources/at/tugraz/damap/db/addContributorRole.yaml
+++ b/src/main/resources/at/tugraz/damap/db/addContributorRole.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: "at/tugraz/damap/addContributorRole"
+      author: Laura Thaci
+      changes:
+        - addColumn:
+            tableName: contributor
+            columns:
+              - column:
+                  name: contributor_role
+                  type: varchar(255)
+                  defaultValue: "CONTRIBUTOR"
+                  constraints:
+                    nullable: true 

--- a/src/main/resources/at/tugraz/damap/db/mainChangeLog.yaml
+++ b/src/main/resources/at/tugraz/damap/db/mainChangeLog.yaml
@@ -4,4 +4,6 @@ databaseChangeLog:
   - include:
       file: at/tugraz/damap/db/addInstitutionalStorage.yaml # insert TU Graz specific storage
   - include:
-      file: at/tugraz/damap/db/fixDmpTitles.yaml 
+      file: at/tugraz/damap/db/fixDmpTitles.yaml
+  - include:
+      file: at/tugraz/damap/db/addContributorRole.yaml


### PR DESCRIPTION
- upgrade base DAMAP dependency to version 4.5.2
- add contributor_role column to contributor table
- update Liquibase changelog to include new schema changes