### PR TITLE
feat: upgrade to DAMAP 4.5.2 and add contributor role support

### DIFF
--- a/src/main/resources/at/tugraz/damap/db/addContributorRole.yaml
+++ b/src/main/resources/at/tugraz/damap/db/addContributorRole.yaml
@@ -2,6 +2,11 @@ databaseChangeLog:
   - changeSet:
       id: "at/tugraz/damap/addContributorRole"
       author: Laura Thaci
+      preConditions:
+        - onFail: MARK_RAN
+        - sqlCheck:
+            expectedResult: 0
+            sql: SELECT COUNT(*) FROM information_schema.columns WHERE table_name = 'contributor' AND column_name = 'contributor_role';
       changes:
         - addColumn:
             tableName: contributor


### PR DESCRIPTION
- upgrade base DAMAP dependency to version 4.5.2
- add contributor_role column to contributor table
- update Liquibase changelog to include new schema changes