### PR TITLE
27 add zenodo as recomended repository

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -98,8 +98,8 @@ rest:
   persons/mp-rest/url: ${damap.persons-url}
   fits/mp-rest/url: ${damap.fits-url}
   r3data:
-    repositories/mp-rest/url: https://www.re3data.org/api/v1/repositories
-    repository/mp-rest/url: https://www.re3data.org/api/v1/repository
+    repositories/mp-rest/url: https://www.re3data.org/api
+    repository/mp-rest/url: https://www.re3data.org/api
     repositories/mp-rest/scope: jakarta.inject.Singleton
     repository/mp-rest/scope: jakarta.inject.Singleton
   openaire/mp-rest/url: http://api.openaire.eu/search/


### PR DESCRIPTION
re3data API is redirecting the duplicate path to the correct one, so no need to include the /v1/repositories part because it's already in the interface.